### PR TITLE
Added fix for build failing due to missing go-vnc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,9 @@ rm -rf pkg/*
 rm -rf $GOPATH/pkg/*
 mkdir -p bin/
 
+# Fix for build failing due to missing go-vnc
+go get github.com/mitchellh/go-vnc
+
 gox \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \


### PR DESCRIPTION
Fix for:

```
dzheng@dzheng-ubuntu-desktop:~/go/src/github.com/xenserver/packer-builder-xenserver$ ./build.sh 
==> Removing old directory...
Number of parallel builds: 7

-->     linux/amd64: github.com/xenserver/packer-builder-xenserver/plugin/builder-xenserver-xva
-->     linux/amd64: github.com/xenserver/packer-builder-xenserver/plugin/builder-xenserver-iso

2 errors occurred:
--> linux/amd64 error: exit status 1
Stderr: builder/xenserver/common/step_type_boot_command.go:7:2: cannot find package "github.com/mitchellh/go-vnc" in any of:
    /home/dzheng/go/src/github.com/xenserver/packer-builder-xenserver/vendor/github.com/mitchellh/go-vnc (vendor tree)
    /usr/local/go/src/github.com/mitchellh/go-vnc (from $GOROOT)
    /home/dzheng/go/src/github.com/mitchellh/go-vnc (from $GOPATH)

--> linux/amd64 error: exit status 1
Stderr: builder/xenserver/common/step_type_boot_command.go:7:2: cannot find package "github.com/mitchellh/go-vnc" in any of:
    /home/dzheng/go/src/github.com/xenserver/packer-builder-xenserver/vendor/github.com/mitchellh/go-vnc (vendor tree)
    /usr/local/go/src/github.com/mitchellh/go-vnc (from $GOROOT)
    /home/dzheng/go/src/github.com/mitchellh/go-vnc (from $GOPATH)
```
