### PR TITLE
Change ISO VDI name from Packer-disk to VMName 0

### DIFF
--- a/builder/xenserver/iso/step_create_instance.go
+++ b/builder/xenserver/iso/step_create_instance.go
@@ -92,7 +92,7 @@ func (self *stepCreateInstance) Run(state multistep.StateBag) multistep.StepActi
 		return multistep.ActionHalt
 	}
 
-	vdi, err := sr.CreateVdi("Packer-disk", int64(config.DiskSize*1024*1024))
+	vdi, err := sr.CreateVdi(config.VMName + " 0", int64(config.DiskSize*1024*1024))
 	if err != nil {
 		ui.Error(fmt.Sprintf("Unable to create packer disk VDI: %s", err.Error()))
 		return multistep.ActionHalt


### PR DESCRIPTION
Should follow XenCenter's naming convention of VMName 0, rather than the generic Packer-disk
