### PR TITLE
Added option to convert VM to template

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -50,6 +50,9 @@ type CommonConfig struct {
 	RawSSHWaitTimeout string `mapstructure:"ssh_wait_timeout"`
 	SSHWaitTimeout    time.Duration
 
+	ConvertToTemplate bool `mapstructure:"convert_to_template"`
+	KeepTemplateVIFs  bool `mapstructure:"keep_template_vifs"`
+
 	OutputDir string `mapstructure:"output_directory"`
 	Format    string `mapstructure:"format"`
 	KeepVM    string `mapstructure:"keep_vm"`

--- a/builder/xenserver/common/step_convert_to_template.go
+++ b/builder/xenserver/common/step_convert_to_template.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+	xsclient "github.com/xenserver/go-xenserver-client"
+)
+
+type StepConvertToTemplate struct{}
+
+func (self *StepConvertToTemplate) Run(state multistep.StateBag) multistep.StepAction {
+	config := state.Get("commonconfig").(CommonConfig)
+	if !config.ConvertToTemplate {
+		return multistep.ActionContinue
+	}
+
+	ui := state.Get("ui").(packer.Ui)
+	client := state.Get("client").(xsclient.XenAPIClient)
+
+	ui.Say("Step: Convert to template")
+
+	uuid := state.Get("instance_uuid").(string)
+	instance, err := client.GetVMByUuid(uuid)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Unable to get VM from UUID '%s': %s", uuid, err.Error()))
+		return multistep.ActionHalt
+	}
+
+	err = instance.SetIsATemplate(true)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error converting VM to a template: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
+	if !config.KeepTemplateVIFs {
+		ui.Say("Destroying template network interfaces")
+
+		vifs, err := instance.GetVIFs()
+		if err != nil {
+			ui.Error(fmt.Sprintf("Error getting VIFs: %s", err.Error()))
+			return multistep.ActionHalt
+		}
+
+		for _, vif := range vifs {
+			err = vif.Destroy()
+			if err != nil {
+				ui.Error(fmt.Sprintf("Error destroying VIF: %s", err.Error()))
+				return multistep.ActionHalt
+			}
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (self *StepConvertToTemplate) Cleanup(state multistep.StateBag) {}

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -317,6 +317,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 		&xscommon.StepDetachVdi{
 			VdiUuidKey: "floppy_vdi_uuid",
 		},
+		new(xscommon.StepConvertToTemplate),
 		new(xscommon.StepExport),
 	}
 

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -180,6 +180,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 		&xscommon.StepDetachVdi{
 			VdiUuidKey: "tools_vdi_uuid",
 		},
+		new(xscommon.StepConvertToTemplate),
 		new(xscommon.StepExport),
 	}
 

--- a/docs/builders/xenserver-iso.html.markdown
+++ b/docs/builders/xenserver-iso.html.markdown
@@ -100,6 +100,9 @@ each category, the available options are alphabetized and described.
   run `xe template-list`. Setting the correct value hints to XenServer how to
   optimize the virtual hardware to work best with that operating system.
 
+* `convert_to_template` (boolean) - Whether to convert the VM to a template
+  prior to exporting. Default is `false`.
+
 * `disk_size` (integer) - The size, in megabytes, of the hard disk to create
   for the VM. By default, this is 40000 (about 40 GB).
 
@@ -143,6 +146,10 @@ each category, the available options are alphabetized and described.
   or while downloading a single URL, it will move on to the next. All URLs
   must point to the same file (same checksum). By default this is empty
   and `iso_url` is used. Only one of `iso_url` or `iso_urls` can be specified.
+
+* `keep_template_vifs` (boolean) - Whether to keep VIFs on the template after
+  converting the VM to a template. Removing them may make the template more generic
+  and reusable. Only applies if `convert_to_template` is `true`. Default is `false`.
 
 * `keep_vm` (string) - Determine when to keep the VM and when to clean it up. This
   can be "always", "never" or "on_success". By default this is "never", and Packer


### PR DESCRIPTION
Add config options for `convert_to_template` and `keep_template_vifs`

When merging with https://github.com/xenserver/packer-builder-xenserver/pull/63
Keep this order:

```
        ...
        new(xscommon.StepConfigureDiskDrives),
        new(xscommon.StepConvertToTemplate),
        new(xscommon.StepExport),
```
