### PR TITLE
Allow XVA builder to use templates already on XenCenter

### DIFF
--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -20,8 +20,9 @@ type config struct {
 	common.PackerConfig   `mapstructure:",squash"`
 	xscommon.CommonConfig `mapstructure:",squash"`
 
-	SourcePath string `mapstructure:"source_path"`
-	VMMemory   uint   `mapstructure:"vm_memory"`
+	SourcePath     string `mapstructure:"source_path"`
+	SourceTemplate string `mapstructure:"source_template"`
+	VMMemory       uint   `mapstructure:"vm_memory"`
 
 	PlatformArgs map[string]string `mapstructure:"platform_args"`
 
@@ -72,8 +73,8 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 
 	// Validation
 
-	if self.config.SourcePath == "" {
-		errs = packer.MultiErrorAppend(errs, fmt.Errorf("A source_path must be specified"))
+	if self.config.SourcePath == "" && self.config.SourceTemplate == "" {
+		errs = packer.MultiErrorAppend(errs, fmt.Errorf("Either source_path or source_template must be specified"))
 	}
 
 	if len(errs.Errors) > 0 {
@@ -107,6 +108,13 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 
 	httpReqChan := make(chan string, 1)
 
+	var stepImportOrInstantiate multistep.Step
+	if self.config.SourceTemplate != "" {
+		stepImportOrInstantiate = new(stepInstantiateTemplate)
+	} else {
+		stepImportOrInstantiate = new(stepImportInstance)
+	}
+
 	//Build the steps
 	steps := []multistep.Step{
 		&xscommon.StepPrepareOutputDir{
@@ -133,7 +141,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 			VdiName:    self.config.ToolsIsoName,
 			VdiUuidKey: "tools_vdi_uuid",
 		},
-		new(stepImportInstance),
+		stepImportOrInstantiate,
 		&xscommon.StepAttachVdi{
 			VdiUuidKey: "floppy_vdi_uuid",
 			VdiType:    xsclient.Floppy,

--- a/builder/xenserver/xva/step_instantiate_template.go
+++ b/builder/xenserver/xva/step_instantiate_template.go
@@ -1,0 +1,83 @@
+package xva
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+	xsclient "github.com/xenserver/go-xenserver-client"
+)
+
+type stepInstantiateTemplate struct {
+	instance *xsclient.VM
+	vdi      *xsclient.VDI
+}
+
+func (self *stepInstantiateTemplate) Run(state multistep.StateBag) multistep.StepAction {
+	client := state.Get("client").(xsclient.XenAPIClient)
+	config := state.Get("config").(config)
+	ui := state.Get("ui").(packer.Ui)
+
+	ui.Say("Step: Instantiate Template")
+
+	var template *xsclient.VM
+	var err error
+
+	if len(config.SourceTemplate) >= 7 && config.SourceTemplate[:7] == "uuid://" {
+		templateUuid := config.SourceTemplate[7:]
+
+		template, err = client.GetVMByUuid(templateUuid)
+		if err != nil {
+			ui.Error(fmt.Sprintf("Could not get template with UUID '%s': %s", templateUuid, err.Error()))
+			return multistep.ActionHalt
+		}
+	} else {
+		templates, err := client.GetVMByNameLabel(config.SourceTemplate)
+		if err != nil {
+			ui.Error(fmt.Sprintf("Error getting template: %s", err.Error()))
+			return multistep.ActionHalt
+		}
+
+		switch {
+		case len(templates) == 0:
+			ui.Error(fmt.Sprintf("Couldn't find a template with the name-label '%s'. Aborting.", config.SourceTemplate))
+			return multistep.ActionHalt
+		case len(templates) > 1:
+			ui.Error(fmt.Sprintf("Found more than one template with the name '%s'. The name must be unique. Aborting.", config.SourceTemplate))
+			return multistep.ActionHalt
+		}
+
+		template = templates[0]
+	}
+
+	self.instance, err = template.Clone(config.VMName)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error cloning template: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
+	err = self.instance.SetIsATemplate(false)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error converting template to a VM: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
+	instanceId, err := self.instance.GetUuid()
+	if err != nil {
+		ui.Error(fmt.Sprintf("Unable to get VM UUID: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+	state.Put("instance_uuid", instanceId)
+
+	err = self.instance.SetDescription(config.VMDescription)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error setting VM description: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
+	ui.Say(fmt.Sprintf("Instantiated template '%s'", instanceId))
+
+	return multistep.ActionContinue
+}
+
+func (self *stepInstantiateTemplate) Cleanup(state multistep.StateBag) {}


### PR DESCRIPTION
Set `source_template` in config rather than `source_path`

Use case:
Build from Windows XVA, which can be very big. This can dramatically decrease build time.
