### PR TITLE
Added documentation for format=xva_compressed

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -186,7 +186,7 @@ func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 	switch c.Format {
 	case "xva", "xva_compressed", "vdi_raw", "vdi_vhd", "none":
 	default:
-		errs = append(errs, errors.New("format must be one of 'xva', 'vdi_raw', 'vdi_vhd', 'none'"))
+		errs = append(errs, errors.New("format must be one of 'xva', 'xva_compressed', 'vdi_raw', 'vdi_vhd', 'none'"))
 	}
 
 	switch c.KeepVM {

--- a/docs/builders/xenserver-iso.html.markdown
+++ b/docs/builders/xenserver-iso.html.markdown
@@ -113,10 +113,10 @@ each category, the available options are alphabetized and described.
   characters (\*, ?, and []) are allowed. Directory names are also allowed,
   which will add all the files found in the directory to the floppy.
 
-* `format` (string) - Either "xva", "vdi_raw" or "none", this specifies the
-  output format of the exported virtual machine. This defaults to "xva". Set to
-  "vdi_raw" to export just the raw disk image. Set to "none" to export nothing;
-  this is only useful with "keep_vm" set to "always" or "on_success".
+* `format` (string) - Either "xva", "xva_compressed", "vdi_raw" or "none", this 
+  specifies the output format of the exported virtual machine. This defaults to "xva". 
+  Set to "vdi_raw" to export just the raw disk image. Set to "none" to export 
+  nothing; this is only useful with "keep_vm" set to "always" or "on_success".
 
 * `http_directory` (string) - Path to a directory to serve using an HTTP
   server. The files in this directory will be available over HTTP that will


### PR DESCRIPTION
I think `xva_compressed` should be the default? When would we not want a smaller output size?
