### PR TITLE
Added functionality to execute scripts on the XenServer host prior to booting VM

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -14,9 +14,10 @@ import (
 )
 
 type CommonConfig struct {
-	Username string `mapstructure:"remote_username"`
-	Password string `mapstructure:"remote_password"`
-	HostIp   string `mapstructure:"remote_host"`
+	Username   string `mapstructure:"remote_username"`
+	Password   string `mapstructure:"remote_password"`
+	HostIp     string `mapstructure:"remote_host"`
+	XenSSHPort uint   `mapstructure:"remote_ssh_port"`
 
 	VMName        string   `mapstructure:"vm_name"`
 	VMDescription string   `mapstructure:"vm_description"`
@@ -27,8 +28,9 @@ type CommonConfig struct {
 	HostPortMin uint `mapstructure:"host_port_min"`
 	HostPortMax uint `mapstructure:"host_port_max"`
 
-	BootCommand     []string `mapstructure:"boot_command"`
-	ShutdownCommand string   `mapstructure:"shutdown_command"`
+	PrebootHostScripts []string `mapstructure:"preboot_host_scripts"`
+	BootCommand        []string `mapstructure:"boot_command"`
+	ShutdownCommand    string   `mapstructure:"shutdown_command"`
 
 	RawBootWait string `mapstructure:"boot_wait"`
 	BootWait    time.Duration
@@ -61,6 +63,10 @@ func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 	var errs []error
 
 	// Set default values
+
+	if c.XenSSHPort == 0 {
+		c.XenSSHPort = 22
+	}
 
 	if c.HostPortMin == 0 {
 		c.HostPortMin = 5900

--- a/builder/xenserver/common/step_preboot_host_scripts.go
+++ b/builder/xenserver/common/step_preboot_host_scripts.go
@@ -1,0 +1,96 @@
+package common
+
+import (
+	"fmt"
+	"github.com/dongyuzheng/easyssh"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+	"path/filepath"
+)
+
+type StepPrebootHostScripts struct {
+	ScriptFolderPath string
+}
+
+func (self *StepPrebootHostScripts) Run(state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	config := state.Get("commonconfig").(CommonConfig)
+
+	ui.Say("Step: Preboot XenServer host scripts")
+
+	if len(config.PrebootHostScripts) == 0 {
+		ui.Say("No scripts to execute")
+		return multistep.ActionContinue
+	}
+
+	uuid := state.Get("instance_uuid").(string)
+	self.ScriptFolderPath = fmt.Sprintf("/tmp/packer-preboot-scripts-%s", uuid)
+
+	ssh := &easyssh.MakeConfig{
+		Server:        config.HostIp,
+		Port:          fmt.Sprintf("%d", config.XenSSHPort),
+		User:          config.Username,
+		Password:      config.Password,
+		OutputHandler: func(s string) { ui.Say(s) },
+	}
+
+	ui.Say(fmt.Sprintf("Creating script folder on XenServer host: %s", self.ScriptFolderPath))
+
+	cmd := fmt.Sprintf("mkdir -p '%s'", self.ScriptFolderPath)
+	_, sessionErr, err := ssh.Exec(cmd)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error executing SSH command: %s", err.Error()))
+		return multistep.ActionHalt
+	} else if sessionErr != nil {
+		ui.Error(fmt.Sprintf("Failed to create script folder: %s\n%s", cmd, sessionErr.Error()))
+		return multistep.ActionHalt
+	}
+
+	for _, script := range config.PrebootHostScripts {
+		scriptBasename := filepath.Base(script)
+		scriptPath := fmt.Sprintf("%s/%s", self.ScriptFolderPath, scriptBasename)
+
+		err = ssh.Upload(script, scriptPath)
+		if err != nil {
+			ui.Error(fmt.Sprintf("Error uploading script: %s\n%s", script, err.Error()))
+			return multistep.ActionHalt
+		}
+
+		ui.Say(fmt.Sprintf("Executing %s ...", scriptBasename))
+		cmd = fmt.Sprintf("chmod +x '%s' && '%s' '%s'", scriptPath, scriptPath, uuid)
+		_, sessionErr, err := ssh.Exec(cmd)
+		if err != nil {
+			ui.Error(fmt.Sprintf("Error executing SSH command: %s", err.Error()))
+			return multistep.ActionHalt
+		} else if sessionErr != nil {
+			ui.Error(fmt.Sprintf("Failed to execute script: %s\n%s", cmd, sessionErr.Error()))
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (self *StepPrebootHostScripts) Cleanup(state multistep.StateBag) {
+	ui := state.Get("ui").(packer.Ui)
+	ui.Say("Cleaning up preboot host scripts")
+	if self.ScriptFolderPath == "" {
+		ui.Say("No scripts to cleanup")
+		return
+	}
+	config := state.Get("commonconfig").(CommonConfig)
+	ssh := &easyssh.MakeConfig{
+		Server:   config.HostIp,
+		Port:     fmt.Sprintf("%d", config.XenSSHPort),
+		User:     config.Username,
+		Password: config.Password,
+	}
+	ui.Say(fmt.Sprintf("Deleting script folder: %s", self.ScriptFolderPath))
+	cmd := fmt.Sprintf("rm -rf '%s'", self.ScriptFolderPath)
+	_, sessionErr, err := ssh.Exec(cmd)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error executing SSH command: %s", err.Error()))
+	} else if sessionErr != nil {
+		ui.Error(fmt.Sprintf("Failed to delete scripts folder: %s\n%s", cmd, sessionErr.Error()))
+	}
+}

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -273,6 +273,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 			VdiUuidKey: "tools_vdi_uuid",
 			VdiType:    xsclient.CD,
 		},
+		new(xscommon.StepPrebootHostScripts),
 		new(xscommon.StepStartVmPaused),
 		new(xscommon.StepGetVNCPort),
 		&xscommon.StepForwardPortOverSSH{

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -142,6 +142,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 			VdiUuidKey: "tools_vdi_uuid",
 			VdiType:    xsclient.CD,
 		},
+		new(xscommon.StepPrebootHostScripts),
 		new(xscommon.StepStartVmPaused),
 		new(xscommon.StepGetVNCPort),
 		&xscommon.StepForwardPortOverSSH{

--- a/docs/builders/xenserver-iso.html.markdown
+++ b/docs/builders/xenserver-iso.html.markdown
@@ -171,6 +171,14 @@ each category, the available options are alphabetized and described.
 }
 ```
 
+* `preboot_host_scripts` (array of strings) - List of scripts to execute on the
+  XenServer host prior to booting the VM. The VM's UUID will be passed into each
+  script as the first parameter. The script can be of any type: bash, python, ruby, etc.
+  Each script must start with a shebang, ie. #!/usr/bin/env bash.
+
+* `remote_ssh_port` (integer) - SSH port of XenServer host. Only useful when using
+  `preboot_host_scripts`. Default is 22.
+
 * `shutdown_command` (string) - The command to use to gracefully shut down
   the machine once all the provisioning is done. By default this is an empty
   string, which tells Packer to just forcefully shut down the machine.

--- a/vendor/github.com/dongyuzheng/easyssh/README.md
+++ b/vendor/github.com/dongyuzheng/easyssh/README.md
@@ -1,0 +1,37 @@
+# easyssh
+
+This fork of easyssh includes useful changes from other forks.
+
+# Description
+
+Package easyssh provides a simple implementation of some SSH protocol features in Go.
+You can simply run command on remote server or upload a file even simple than native console SSH client.
+Do not need to think about Dials, sessions, defers and public keys... Let easyssh will be think about it!
+
+# Install
+
+```go
+go get github.com/dongyuzheng/easyssh
+```
+
+# Parameters
+
+```go
+type MakeConfig struct {
+	// Required
+	Server   string // Remote machine address (required)
+	User     string // Remote user name (required)
+	Password string // Password to user
+	Key      string // Path to private key on local machine
+
+	// Optional
+	Port          string       // SSH port, default 22
+	EnablePTY     bool         // PTY session, default false
+	OutputHandler func(string) // Line-by-line handler for output, default does nothing
+}
+```
+
+# Examples
+
+### 1. [Execute a command with live output, and get output](examples/exec.go)
+### 2. [Upload a file](examples/upload.go)

--- a/vendor/github.com/dongyuzheng/easyssh/easyssh.go
+++ b/vendor/github.com/dongyuzheng/easyssh/easyssh.go
@@ -1,0 +1,244 @@
+// Package easyssh provides a simple implementation of some SSH protocol
+// features in Go. You can simply run a command on a remote server or get a file
+// even simpler than native console SSH client. You don't need to think about
+// Dials, sessions, defers, or public keys... Let easyssh think about it!
+package easyssh
+
+import (
+	"bufio"
+	"fmt"
+	"golang.org/x/crypto/ssh"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+var keyMap map[string][]byte = make(map[string][]byte)
+
+type MakeConfig struct {
+	// Required
+	Server   string // Remote machine address (required)
+	User     string // Remote user name (required)
+	Password string // Password to user
+	Key      string // Path to private key on local machine
+
+	// Optional
+	Port          string       // SSH port, default 22
+	EnablePTY     bool         // PTY session, default false
+	OutputHandler func(string) // Line-by-line handler for output, default does nothing
+
+	// Don't touch
+	Update bool
+	client *ssh.Client
+}
+
+// returns ssh.Signer from user you running app home path + cutted key path.
+// (ex. pubkey,err := getKeyFile("/.ssh/id_rsa") )
+func getKeyFile(keypath string) (pubkey ssh.Signer, err error) {
+	var buf []byte
+	var ok bool
+	if buf, ok = keyMap[keypath]; !ok {
+		file := keypath
+		buf, err = ioutil.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		keyMap[keypath] = buf
+	}
+	pubkey, err = ssh.ParsePrivateKey(buf)
+	if err != nil {
+		return nil, err
+	}
+	return pubkey, nil
+
+}
+
+// connects to remote server using MakeConfig struct and returns *ssh.Session
+func (ssh_conf *MakeConfig) connect() (*ssh.Session, error) {
+	// auths holds the detected ssh auth methods
+	auths := []ssh.AuthMethod{}
+
+	// figure out what auths are requested, what is supported
+	if ssh_conf.Password != "" {
+		auths = append(auths, ssh.Password(ssh_conf.Password))
+
+		auths = append(auths, ssh.KeyboardInteractive(func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+			// Just send the password back for all questions
+			answers := make([]string, len(questions))
+			for i := range answers {
+				answers[i] = ssh_conf.Password // replace this
+			}
+			return answers, nil
+		}))
+	}
+
+	// Default port 22
+	if ssh_conf.Port == "" {
+		ssh_conf.Port = "22"
+	}
+
+	// Default current user
+	if ssh_conf.User == "" {
+		ssh_conf.User = os.Getenv("USER")
+	}
+
+	//	if sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
+	//		auths = append(auths, ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers))
+	//		defer sshAgent.Close()
+	//	}
+
+	if pubkey, err := getKeyFile(ssh_conf.Key); err == nil {
+		auths = append(auths, ssh.PublicKeys(pubkey))
+	}
+
+	config := &ssh.ClientConfig{
+		User: ssh_conf.User,
+		Auth: auths,
+	}
+
+	if ssh_conf.client == nil || ssh_conf.Update {
+		if ssh_conf.client != nil {
+			ssh_conf.client.Close()
+		}
+		var err error
+		ssh_conf.client, err = ssh.Dial("tcp", ssh_conf.Server+":"+ssh_conf.Port, config)
+		if err != nil {
+			return nil, err
+		}
+		ssh_conf.Update = false
+	}
+
+	session, err := ssh_conf.client.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	if ssh_conf.EnablePTY {
+		modes := ssh.TerminalModes{
+			ssh.ECHO:          0,
+			ssh.TTY_OP_ISPEED: 144000,
+			ssh.TTY_OP_OSPEED: 144000,
+		}
+
+		if err := session.RequestPty("xterm", 1024, 1024, modes); err != nil {
+			session.Close()
+			return nil, err
+		}
+	}
+
+	return session, nil
+}
+
+// Stream returns one channel that combines the stdout and stderr of the command
+// as it is run on the remote machine, and another that sends true when the
+// command is done. The sessions and channels will then be closed.
+func (ssh_conf *MakeConfig) Stream(command string) (output chan string, done chan bool, err error, sessionErr error) {
+	// connect to remote host
+	session, err := ssh_conf.connect()
+	if err != nil {
+		return output, done, err, sessionErr
+	}
+	outReader, err := session.StdoutPipe()
+	if err != nil {
+		return output, done, err, sessionErr
+	}
+	errReader, err := session.StderrPipe()
+	if err != nil {
+		return output, done, err, sessionErr
+	}
+	// combine outputs, create a line-by-line scanner
+	outputReader := io.MultiReader(outReader, errReader)
+	sessionErr = session.Run(command)
+	scanner := bufio.NewScanner(outputReader)
+	// continuously send the command's output over the channel
+	outputChan := make(chan string)
+	done = make(chan bool)
+	go func(scanner *bufio.Scanner, out chan string, done chan bool) {
+		defer close(outputChan)
+		defer close(done)
+		for scanner.Scan() {
+			outputChan <- scanner.Text()
+		}
+		// close all of our open resources
+		done <- true
+		session.Close()
+	}(scanner, outputChan, done)
+	return outputChan, done, err, sessionErr
+}
+
+// Execute command on remote machine
+func (ssh_conf *MakeConfig) Exec(command string) (outStr string, sessionErr error, err error) {
+	outChan, doneChan, err, sessionErr := ssh_conf.Stream(command)
+	if err != nil {
+		ssh_conf.Update = true
+		outChan, doneChan, err, sessionErr = ssh_conf.Stream(command)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+
+	if ssh_conf.OutputHandler == nil {
+		ssh_conf.OutputHandler = func(string) {}
+	}
+
+	// read from the output channel until the done signal is passed
+	stillGoing := true
+	for stillGoing {
+		select {
+		case <-doneChan:
+			stillGoing = false
+		case line := <-outChan:
+			ssh_conf.OutputHandler(line)
+			outStr += line + "\n"
+		}
+	}
+
+	// outstr is a merge of stdout and stderr streams
+	return outStr, sessionErr, nil
+}
+
+// Upload a file
+func (ssh_conf *MakeConfig) Upload(localFile string, remoteFile string) error {
+	session, err := ssh_conf.connect()
+
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	targetFile := filepath.Base(localFile)
+
+	src, srcErr := os.Open(localFile)
+
+	if srcErr != nil {
+		return srcErr
+	}
+
+	srcStat, statErr := src.Stat()
+
+	if statErr != nil {
+		return statErr
+	}
+
+	go func() {
+		w, _ := session.StdinPipe()
+
+		fmt.Fprintln(w, "C0644", srcStat.Size(), targetFile)
+
+		if srcStat.Size() > 0 {
+			io.Copy(w, src)
+			fmt.Fprint(w, "\x00")
+			w.Close()
+		} else {
+			fmt.Fprint(w, "\x00")
+			w.Close()
+		}
+	}()
+
+	if err := session.Run(fmt.Sprintf("scp -t '%s'", remoteFile)); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Use case: Setting GPU passthroughs

* `preboot_host_scripts` (array of strings) - List of scripts to execute on the
  XenServer host prior to booting the VM. The VM's UUID will be passed into each
  script as the first parameter. The script can be of any type: bash, python, ruby, etc.
  Each script must start with a shebang, ie. #!/usr/bin/env bash.

* `remote_ssh_port` (integer) - SSH port of XenServer host. Only useful when using
  `preboot_host_scripts`. Default is 22.